### PR TITLE
Failure result summary details

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
@@ -233,12 +233,8 @@ matrix_id = "matrix-neze8iacti7na"
 
           device = "Device:"
           dimensionValues = step["dimensionValue"]
-          UI.message("---- Teststep: #{dimensionValues}")
           dimensionValues.each do |dimensionValue|
-            name = dimensionValue["key"]
             value = dimensionValue["value"]
-            UI.message("DIMENSION name: #{name}")
-            UI.message("DIMENSION value: #{value}")
             device += " " + value
           end
           UI.message("#{device}")
@@ -250,12 +246,13 @@ matrix_id = "matrix-neze8iacti7na"
           testCases.each do |testCase|
             name = testCase["testCaseReference"]["name"]
             status = testCase["status"]
-            UI.message("Testcase name: #{name}")
-            UI.message("Testcase status: #{status}")
-            if status == "failure"
-              failureTests = " " + name
+            #UI.message("Testcase name: #{name}")
+            #UI.message("Testcase status: #{status}")
+            if status == "failed"
+              failureTests += " " + name
             end
           end
+          UI.message(failureTests)
 
           run_duration_sec = step["runDuration"]["seconds"] || 0
           UI.message("Execution time: #{run_duration_sec} seconds")

--- a/lib/fastlane/plugin/firebase_test_lab/module.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/module.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module FirebaseTestLab
-    VERSION = "1.0.8"
+    VERSION = "1.0.9"
     PLUGIN_NAME = "fastlane-plugin-firebase_test_lab"
   end
 end


### PR DESCRIPTION
With this change we  can make overviews like this by returning this information on a dictionary when a test failed:
<img width="626" alt="Screenshot 2020-09-30 at 17 22 52" src="https://user-images.githubusercontent.com/12713254/94705673-9c999300-0341-11eb-91b0-a7ac8e4f9cde.png">
