### PR TITLE
Allow Xcode version to be specified in the parameters

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
@@ -71,7 +71,8 @@ module Fastlane
                                           result_storage,
                                           params[:devices],
                                           params[:timeout_sec],
-                                          params[:gcp_additional_client_info])
+                                          params[:gcp_additional_client_info],
+                                          params[:xcode_version])
 
         # In theory, matrix_id should be available. Keep it to catch unexpected Firebase Test Lab API response
         if matrix_id.nil?

--- a/lib/fastlane/plugin/firebase_test_lab/helper/ftl_service.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ftl_service.rb
@@ -86,13 +86,23 @@ module Fastlane
         end
       end
 
-      def start_job(gcp_project, app_path, result_path, devices, timeout_sec, additional_client_info)
+      def start_job(gcp_project, app_path, result_path, devices, timeout_sec, additional_client_info, xcode_version)
         if additional_client_info.nil? 
           additional_client_info = { version: VERSION }
         else
           additional_client_info["version"] = VERSION
         end
         additional_client_info = additional_client_info.map { |k,v| { key: k, value: v } }
+
+        ios_xc_test_hash = {
+          testsZip: {
+            gcsPath: app_path
+          }
+        }
+
+        if !xcode_version.nil?
+          ios_xc_test_hash.merge!({ xcodeVersion: xcode_version})
+        end
 
         body = {
           projectId: gcp_project,
@@ -101,11 +111,7 @@ module Fastlane
               seconds: timeout_sec
             },
             iosTestSetup: {},
-            iosXcTest: {
-              testsZip: {
-                gcsPath: app_path
-              }
-            }
+            iosXcTest: ios_xc_test_hash
           },
           environmentMatrix: {
             iosDeviceList: {

--- a/lib/fastlane/plugin/firebase_test_lab/module.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/module.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module FirebaseTestLab
-    VERSION = "1.0.9"
+    VERSION = "1.0.10"
     PLUGIN_NAME = "fastlane-plugin-firebase_test_lab"
   end
 end

--- a/lib/fastlane/plugin/firebase_test_lab/options.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/options.rb
@@ -98,7 +98,12 @@ module Fastlane
                                        description: "The directory to save the output results. Default: firebase",
                                        is_string: true,
                                        optional: true,
-                                       default_value: "firebase")                                                 
+                                       default_value: "firebase"),
+          FastlaneCore::ConfigItem.new(key: :xcode_version,
+                                       description: "Xcode version to be used by Firebase TestLab (if not filled then default will be used",
+                                       is_string: true,
+                                       default_value: nil,
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
Allow Xcode version to be specified in the parameters.

This is necessary for supporting iOS 14 (with Xcode 12.1) as currently Firebase Test Lab still defaults to Xcode 11.7 but does support Xcode 12.1 since December 1st.