### PR TITLE
Skip successful tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ firebase_test_lab_ios_xctest(
 - `android_test_apk`: The path for your android test apk. Default: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 - `extra_options`: Extra options that you need to pass to the gcloud command. Default: empty string
 - `retry_if_failed`: If set to true and a test failed, the test suite will be rerun once. Default: nil, no reruns
+- `print_successful_test`: If set to true all successful tests will be printed, by default only failed tests will be printed. Default: nil, no successful tests printed
 
 ## Issues and Feedback
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ firebase_test_lab_ios_xctest(
 - `android_test_apk`: The path for your android test apk. Default: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
 - `extra_options`: Extra options that you need to pass to the gcloud command. Default: empty string
 - `retry_if_failed`: If set to true and a test failed, the test suite will be rerun once. Default: nil, no reruns
-- `print_successful_test`: If set to true all successful tests will be printed, by default only failed tests will be printed. Default: nil, no successful tests printed
+- `print_successful_test`: If set to true all successful tests will be printed, by default only failed tests will be printed. Default: false, no successful tests printed
 
 ## Issues and Feedback
 

--- a/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
@@ -267,8 +267,10 @@ module Fastlane
             testCases.each do |testCase|
               name = testCase["testCaseReference"]["name"]
               status = testCase["status"]
-              if (print_successful_test == true && status.nil?)
+              if status.nil?
+                if print_successful_test
                 testCaseSummary += ":white_check_mark: " + name + "\n"
+                end
               else
                 testCaseSummary += ":fire: " + name + "\n"
               end

--- a/lib/fastlane/plugin/firebase_test_lab/options.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/options.rb
@@ -125,9 +125,8 @@ module Fastlane
                                        default_value: nil),
           FastlaneCore::ConfigItem.new(key: :print_successful_test,
                                        description: "Set to true all successful tests will be printed. Default: nil",
-                                       is_string: false,
-                                       optional: true,
-                                       default_value: nil)
+                                       default_value: false,
+                                       type: Fastlane::Boolean)
 
         ]
       end

--- a/lib/fastlane/plugin/firebase_test_lab/options.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/options.rb
@@ -122,6 +122,11 @@ module Fastlane
                                        description: "Set to true if you want to rerun test sute when failed. Default: nil",
                                        is_string: false,
                                        optional: true,
+                                       default_value: nil),
+          FastlaneCore::ConfigItem.new(key: :print_successful_test,
+                                       description: "Set to true all successful tests will be printed. Default: nil",
+                                       is_string: false,
+                                       optional: true,
                                        default_value: nil)
 
         ]


### PR DESCRIPTION
 If print_successful_test  is set to true all successful tests will be printed, by default only failed tests will be printed. 
Default: nil, no successful tests printed